### PR TITLE
docs: clarify clipboard instance availability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "clipin"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arboard",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clipin"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 authors = ["kaoru <k@warpnine.io>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Rust library to get text from clipboard or stdin.
 
 ## Usage
 
-Enable exactly one feature: `async` or `sync`. Returns trimmed text and optionally the clipboard instance (clipboard is `None` when stdin is used).
+Enable exactly one feature: `async` or `sync`. Returns trimmed text and optionally the clipboard instance if available.
 
 ### Async
 


### PR DESCRIPTION
The documentation previously implied that clipboard would be `None` when
stdin is used, but this detail is implementation-specific and shouldn't
be part of the public API contract.